### PR TITLE
Add support for OAuth authentication

### DIFF
--- a/bitbucket/__init__.py
+++ b/bitbucket/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.4.3'
+__version__ = '0.4.4dev'

--- a/bitbucket/tests/private/__init__.py
+++ b/bitbucket/tests/private/__init__.py
@@ -1,7 +1,15 @@
 # -*- coding: utf-8 -*-
 try:
-    # TODO : check validity of credentials ?
-    from settings import USERNAME, PASSWORD
+    # Try and get OAuth credentials first, if that fails try basic auth
+    from settings import USERNAME, CONSUMER_KEY, CONSUMER_SECRET
+    PASSWORD = None
 except ImportError:
-    # Private tests require username and password of an existing user.
-    exit('Please provide USERNAME and PASSWORD in bitbucket/tests/private/settings.py .')
+    try:
+        # TODO : check validity of credentials ?
+        from settings import USERNAME, PASSWORD
+        CONSUMER_KEY = None
+        CONSUMER_SECRET = None
+    except ImportError:
+        # Private tests require username and password of an existing user.
+        exit('Please provide either USERNAME and PASSWORD or USERNAME, CONSUMER_KEY and CONSUMER_SECRET in bitbucket/tests/private/settings.py.')
+

--- a/bitbucket/tests/private/__main__.py
+++ b/bitbucket/tests/private/__main__.py
@@ -2,7 +2,7 @@
 # run with `site-packages$> python -m bitbucket.tests.private`
 import unittest
 
-from bitbucket.tests.private import USERNAME, PASSWORD
+from bitbucket.tests.private import USERNAME, PASSWORD, CONSUMER_KEY, CONSUMER_SECRET
 from bitbucket.tests.private.private import BitbucketAuthenticatedMethodsTest
 from bitbucket.tests.private.repository import RepositoryAuthenticatedMethodsTest, ArchiveRepositoryAuthenticatedMethodsTest
 from bitbucket.tests.private.issue import IssueAuthenticatedMethodsTest


### PR DESCRIPTION
Instead of using a password to authenticate you can now supply OAuth credentials.

``` python```
from bitbucket import Bitbucket
import webbrowser

bb = Bitbucket(username)

# Start authorization
(success, msg) = bb.authorize(consumer_key, consumer_secret, u'http://localhost/')
if not success:
    sys.exit(msg)

# Redirect user to web browser
webbrowser.open(bb.url('AUTHENTICATE', token=bb.access_token))

# Copy the verifier field from the URL in the browser into the console
oauth_verifier = raw_input('Enter verifier from url [oauth_verifier]')

# Finalize authorization
(success, msg) = bb.verify(oauth_verifier)
```
