### PR TITLE
Pull private repos for any accessible owner.

### DIFF
--- a/bitbucket/bitbucket.py
+++ b/bitbucket/bitbucket.py
@@ -227,17 +227,19 @@ class Bitbucket(object):
         s = Session()
         resp = s.send(r.prepare())
         status = resp.status_code
-        text = resp.text
+        content = resp.content  # Includes binary
+
         error = resp.reason
         if status >= 200 and status < 300:
-            if text:
+            if content:
                 try:
-                    return (True, json.loads(text))
+                    return (True, json.loads(content))
                 except TypeError:
                     pass
                 except ValueError:
                     pass
-            return (True, text)
+
+            return (True, content)
         elif status >= 300 and status < 400:
             return (
                 False,

--- a/bitbucket/issue.py
+++ b/bitbucket/issue.py
@@ -37,21 +37,23 @@ class Issue(object):
     def issue_id(self):
         del self._issue_id
 
-    def all(self, repo_slug=None, params=None):
+    def all(self, repo_slug=None, params=None, owner=None):
         """ Get issues from one of your repositories.
         """
+        owner = owner or self.bitbucket.username
         repo_slug = repo_slug or self.bitbucket.repo_slug or ''
-        url = self.bitbucket.url('GET_ISSUES', username=self.bitbucket.username, repo_slug=repo_slug)
+        url = self.bitbucket.url('GET_ISSUES', username=owner, repo_slug=repo_slug)
         return self.bitbucket.dispatch('GET', url, auth=self.bitbucket.auth, params=params)
 
-    def get(self, issue_id, repo_slug=None):
+    def get(self, issue_id, repo_slug=None, owner=None):
         """ Get an issue from one of your repositories.
         """
         repo_slug = repo_slug or self.bitbucket.repo_slug or ''
-        url = self.bitbucket.url('GET_ISSUE', username=self.bitbucket.username, repo_slug=repo_slug, issue_id=issue_id)
+        owner = owner or self.bitbucket.username
+        url = self.bitbucket.url('GET_ISSUE', username=owner, repo_slug=repo_slug, issue_id=issue_id)
         return self.bitbucket.dispatch('GET', url, auth=self.bitbucket.auth)
 
-    def create(self, repo_slug=None, **kwargs):
+    def create(self, repo_slug=None, owner=None, **kwargs):
         """
         Add an issue to one of your repositories.
         Each issue require a different set of attributes,
@@ -67,11 +69,12 @@ class Issue(object):
             * status: The status of the issue (new, open, resolved, on hold, invalid, duplicate, or wontfix).
             * kind: The kind of issue (bug, enhancement, or proposal).
         """
+        owner = owner or self.bitbucket.username
         repo_slug = repo_slug or self.bitbucket.repo_slug or ''
-        url = self.bitbucket.url('CREATE_ISSUE', username=self.bitbucket.username, repo_slug=repo_slug)
+        url = self.bitbucket.url('CREATE_ISSUE', username=owner, repo_slug=repo_slug)
         return self.bitbucket.dispatch('POST', url, auth=self.bitbucket.auth, **kwargs)
 
-    def update(self, issue_id, repo_slug=None, **kwargs):
+    def update(self, issue_id, repo_slug=None, owner=None, **kwargs):
         """
         Update an issue to one of your repositories.
         Each issue require a different set of attributes,
@@ -87,13 +90,15 @@ class Issue(object):
             * status: The status of the issue (new, open, resolved, on hold, invalid, duplicate, or wontfix).
             * kind: The kind of issue (bug, enhancement, or proposal).
         """
+        owner = owner or self.bitbucket.username
         repo_slug = repo_slug or self.bitbucket.repo_slug or ''
-        url = self.bitbucket.url('UPDATE_ISSUE', username=self.bitbucket.username, repo_slug=repo_slug, issue_id=issue_id)
+        url = self.bitbucket.url('UPDATE_ISSUE', username=owner, repo_slug=repo_slug, issue_id=issue_id)
         return self.bitbucket.dispatch('PUT', url, auth=self.bitbucket.auth, **kwargs)
 
-    def delete(self, issue_id, repo_slug=None):
+    def delete(self, issue_id, repo_slug=None, owner=None):
         """ Delete an issue from one of your repositories.
         """
+        owner = owner or self.bitbucket.username
         repo_slug = repo_slug or self.bitbucket.repo_slug or ''
-        url = self.bitbucket.url('DELETE_ISSUE', username=self.bitbucket.username, repo_slug=repo_slug, issue_id=issue_id)
+        url = self.bitbucket.url('DELETE_ISSUE', username=owner, repo_slug=repo_slug, issue_id=issue_id)
         return self.bitbucket.dispatch('DELETE', url, auth=self.bitbucket.auth)

--- a/bitbucket/issue_comment.py
+++ b/bitbucket/issue_comment.py
@@ -18,63 +18,68 @@ class IssueComment(object):
         self.bitbucket.URLS.update(URLS)
         self.issue_id = issue.issue_id
 
-    def all(self, issue_id=None, repo_slug=None):
+    def all(self, issue_id=None, repo_slug=None , owner=None):
         """ Get issue comments from one of your repositories.
         """
         issue_id = issue_id or self.issue_id
         repo_slug = repo_slug or self.bitbucket.repo_slug or ''
+        owner = owner or self.bitbucket.username
         url = self.bitbucket.url('GET_COMMENTS',
-                                 username=self.bitbucket.username,
+                                 username=owner,
                                  repo_slug=repo_slug,
                                  issue_id=issue_id)
         return self.bitbucket.dispatch('GET', url, auth=self.bitbucket.auth)
 
-    def get(self, comment_id, issue_id=None, repo_slug=None):
+    def get(self, comment_id, issue_id=None, repo_slug=None, owner=None):
         """ Get an issue from one of your repositories.
         """
         issue_id = issue_id or self.issue_id
+        owner = owner or self.bitbucket.username
         repo_slug = repo_slug or self.bitbucket.repo_slug or ''
         url = self.bitbucket.url('GET_COMMENT',
-                                 username=self.bitbucket.username,
+                                 username=owner,
                                  repo_slug=repo_slug,
                                  issue_id=issue_id,
                                  comment_id=comment_id)
         return self.bitbucket.dispatch('GET', url, auth=self.bitbucket.auth)
 
-    def create(self, issue_id=None, repo_slug=None, **kwargs):
+    def create(self, issue_id=None, repo_slug=None, owner=None, **kwargs):
         """ Add an issue comment to one of your repositories.
             Each issue comment require only the content data field
             the system autopopulate the rest.
         """
         issue_id = issue_id or self.issue_id
         repo_slug = repo_slug or self.bitbucket.repo_slug or ''
+        owner = owner or self.bitbucket.username
         url = self.bitbucket.url('CREATE_COMMENT',
-                                 username=self.bitbucket.username,
+                                 username=owner,
                                  repo_slug=repo_slug,
                                  issue_id=issue_id)
         return self.bitbucket.dispatch('POST', url, auth=self.bitbucket.auth, **kwargs)
 
-    def update(self, comment_id, issue_id=None, repo_slug=None, **kwargs):
+    def update(self, comment_id, issue_id=None, repo_slug=None, owner=None, **kwargs):
         """ Update an issue comment in one of your repositories.
             Each issue comment require only the content data field
             the system autopopulate the rest.
         """
         issue_id = issue_id or self.issue_id
         repo_slug = repo_slug or self.bitbucket.repo_slug or ''
+        owner = owner or self.bitbucket.username
         url = self.bitbucket.url('UPDATE_COMMENT',
-                                 username=self.bitbucket.username,
+                                 username=owner,
                                  repo_slug=repo_slug,
                                  issue_id=issue_id,
                                  comment_id=comment_id)
         return self.bitbucket.dispatch('PUT', url, auth=self.bitbucket.auth, **kwargs)
 
-    def delete(self, comment_id, issue_id=None, repo_slug=None):
+    def delete(self, comment_id, issue_id=None, repo_slug=None, owner=None):
         """ Delete an issue from one of your repositories.
         """
         issue_id = issue_id or self.issue_id
         repo_slug = repo_slug or self.bitbucket.repo_slug or ''
+        owner = owner or self.bitbucket.username
         url = self.bitbucket.url('DELETE_COMMENT',
-                                 username=self.bitbucket.username,
+                                 username=owner,
                                  repo_slug=repo_slug,
                                  issue_id=issue_id,
                                  comment_id=comment_id)

--- a/bitbucket/pullrequest.py
+++ b/bitbucket/pullrequest.py
@@ -50,7 +50,7 @@ class PullRequest(object):
         """
         repo_slug = repo_slug or self.bitbucket.repo_slug or ''
         owner = owner or self.bitbucket.username
-        url = self.bitbucket.url_v2('GET_PULLREQUEST', username=owner, repo_slug=repo_slug, issue_id=issue_id)
+        url = self.bitbucket.url_v2('GET_PULLREQUEST', username=owner, repo_slug=repo_slug, issue_id=pullrequest_id)
         return self.bitbucket.dispatch('GET', url, auth=self.bitbucket.auth)
 
     def create(self, repo_slug=None, owner=None, **kwargs):
@@ -62,7 +62,7 @@ class PullRequest(object):
 
             * title: A string representing the request title.
             * description: The description of the pull request.
-            * name: 
+            * name:
             * milestone: The milestone associated with the issue.
             * version: The version associated with the issue.
             * responsible: The username of the person responsible for the issue.

--- a/bitbucket/pullrequest.py
+++ b/bitbucket/pullrequest.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+from .pullrequest_comment import PullRequestComment
+
+
+URLS = {
+    # Issues
+    'GET_PULLREQUESTS': 'repositories/%(username)s/%(repo_slug)s/pullrequests/',
+    'GET_PULLREQUEST': 'repositories/%(username)s/%(repo_slug)s/pullrequests/%(issue_id)s/',
+    'CREATE_PULLREQUEST': 'repositories/%(username)s/%(repo_slug)s/pullrequests/',
+    'UPDATE_PULLREQUEST': 'repositories/%(username)s/%(repo_slug)s/pullrequests/%(issue_id)s/',
+    'DELETE_PULLREQUEST': 'repositories/%(username)s/%(repo_slug)s/pullrequests/%(issue_id)s/',
+}
+
+
+class PullRequest(object):
+    """ This class provide issue-related methods to Bitbucket objects."""
+
+    def __init__(self, bitbucket, pullrequest_id=None):
+        self.bitbucket = bitbucket
+        self.bitbucket.URLS.update(URLS)
+        self.pullrequest_id = pullrequest_id
+        self.comment = PullRequestComment(self)
+
+    @property
+    def pullrequest_id(self):
+        """Your repository slug name."""
+        return self._pullrequest_id
+
+    @pullrequest_id.setter
+    def pullrequest_id(self, value):
+        if value:
+            self._pullrequest_id = int(value)
+        elif value is None:
+            self._pullrequest_id = None
+
+    @pullrequest_id.deleter
+    def pullrequest_id(self):
+        del self._pullrequest_id
+
+    def all(self, repo_slug=None, params=None, owner=None):
+        """ Get PullRequests from one of your repositories.
+        """
+        owner = owner or self.bitbucket.username
+        repo_slug = repo_slug or self.bitbucket.repo_slug or ''
+        url = self.bitbucket.url_v2('GET_PULLREQUESTS', username=owner, repo_slug=repo_slug)
+        return self.bitbucket.dispatch('GET', url, auth=self.bitbucket.auth, params=params)
+
+    def get(self, pullrequest_id, repo_slug=None, owner=None):
+        """ Get a PullRequest from one of your repositories.
+        """
+        repo_slug = repo_slug or self.bitbucket.repo_slug or ''
+        owner = owner or self.bitbucket.username
+        url = self.bitbucket.url_v2('GET_PULLREQUEST', username=owner, repo_slug=repo_slug, issue_id=issue_id)
+        return self.bitbucket.dispatch('GET', url, auth=self.bitbucket.auth)
+
+    def create(self, repo_slug=None, owner=None, **kwargs):
+        """
+        Add a PullRequest to one of your repositories.
+        Each issue require a different set of attributes,
+        you can pass them as keyword arguments (attributename='attributevalue').
+        Attributes are:
+
+            * title: A string representing the request title.
+            * description: The description of the pull request.
+            * name: 
+            * milestone: The milestone associated with the issue.
+            * version: The version associated with the issue.
+            * responsible: The username of the person responsible for the issue.
+            * status: The status of the issue (new, open, resolved, on hold, invalid, duplicate, or wontfix).
+            * kind: The kind of issue (bug, enhancement, or proposal).
+        """
+        owner = owner or self.bitbucket.username
+        repo_slug = repo_slug or self.bitbucket.repo_slug or ''
+        url = self.bitbucket.url_v2('CREATE_PULLREQUEST', username=owner, repo_slug=repo_slug)
+        return self.bitbucket.dispatch('POST', url, auth=self.bitbucket.auth, **kwargs)
+
+    def update(self, issue_id, repo_slug=None, owner=None, **kwargs):
+        """
+        Update an issue to one of your repositories.
+        Each issue require a different set of attributes,
+        you can pass them as keyword arguments (attributename='attributevalue').
+        Attributes are:
+
+            * title: The title of the new issue.
+            * content: The content of the new issue.
+            * component: The component associated with the issue.
+            * milestone: The milestone associated with the issue.
+            * version: The version associated with the issue.
+            * responsible: The username of the person responsible for the issue.
+            * status: The status of the issue (new, open, resolved, on hold, invalid, duplicate, or wontfix).
+            * kind: The kind of issue (bug, enhancement, or proposal).
+        """
+        owner = owner or self.bitbucket.username
+        repo_slug = repo_slug or self.bitbucket.repo_slug or ''
+        url = self.bitbucket.url_v2('UPDATE_PULLREQUEST', username=owner, repo_slug=repo_slug, issue_id=issue_id)
+        return self.bitbucket.dispatch('PUT', url, auth=self.bitbucket.auth, **kwargs)
+
+    def delete(self, issue_id, repo_slug=None, owner=None):
+        """ Delete an issue from one of your repositories.
+        """
+        owner = owner or self.bitbucket.username
+        repo_slug = repo_slug or self.bitbucket.repo_slug or ''
+        url = self.bitbucket.url_v2('DELETE_PULLREQUEST', username=owner, repo_slug=repo_slug, issue_id=issue_id)
+        return self.bitbucket.dispatch('DELETE', url, auth=self.bitbucket.auth)

--- a/bitbucket/pullrequest_comment.py
+++ b/bitbucket/pullrequest_comment.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+URLS = {
+    # Issue comments
+    'GET_COMMENTS': 'repositories/%(username)s/%(repo_slug)s/pullrequests/%(pullrequest_id)s/comments/',
+    'GET_COMMENT': 'repositories/%(username)s/%(repo_slug)s/pullrequests/%(pullrequest_id)s/comments/%(comment_id)s/',
+    'CREATE_COMMENT': 'repositories/%(username)s/%(repo_slug)s/pullrequests/%(pullrequest_id)s/comments/',
+    'UPDATE_COMMENT': 'repositories/%(username)s/%(repo_slug)s/pullrequests/%(pullrequest_id)s/comments/%(comment_id)s/',
+    'DELETE_COMMENT': 'repositories/%(username)s/%(repo_slug)s/pullrequests/%(pullrequest_id)s/comments/%(comment_id)s/',
+}
+
+
+class PullRequestComment(object):
+    """ This class provide PullRequest's comments related methods to Bitbucket objects."""
+
+    def __init__(self, pullrequest):
+        self.pullrequest = pullrequest
+        self.bitbucket = self.pullrequest.bitbucket
+        self.bitbucket.URLS.update(URLS)
+        self.pullrequest_id = pullrequest.pullrequest_id
+
+    def all(self, pullrequest_id=None, repo_slug=None):
+        """ Get PullRequest comments from one of your repositories.
+        """
+        pullrequest_id = pullrequest_id or self.pullrequest_id
+        repo_slug = repo_slug or self.bitbucket.repo_slug or ''
+        url = self.bitbucket.url('GET_COMMENTS',
+                                 username=self.bitbucket.username,
+                                 repo_slug=repo_slug,
+                                 pullrequest_id=pullrequest_id)
+        return self.bitbucket.dispatch('GET', url, auth=self.bitbucket.auth)
+
+    def get(self, comment_id, pullrequest_id=None, repo_slug=None):
+        """ Get a PullRequest from one of your repositories.
+        """
+        pullrequest_id = pullrequest_id or self.pullrequest_id
+        repo_slug = repo_slug or self.bitbucket.repo_slug or ''
+        url = self.bitbucket.url('GET_COMMENT',
+                                 username=self.bitbucket.username,
+                                 repo_slug=repo_slug,
+                                 pullrequest_id=pullrequest_id,
+                                 comment_id=comment_id)
+        return self.bitbucket.dispatch('GET', url, auth=self.bitbucket.auth)
+
+    def create(self, pullrequest_id=None, repo_slug=None, **kwargs):
+        """ Add a PullRequest comment to one of your repositories.
+            Each PullRequest comment require only the content data field
+            the system autopopulate the rest.
+        """
+        pullrequest_id = pullrequest_id or self.pullrequest_id
+        repo_slug = repo_slug or self.bitbucket.repo_slug or ''
+        url = self.bitbucket.url('CREATE_COMMENT',
+                                 username=self.bitbucket.username,
+                                 repo_slug=repo_slug,
+                                 pullrequest_id=pullrequest_id)
+        return self.bitbucket.dispatch('POST', url, auth=self.bitbucket.auth, **kwargs)
+
+    def update(self, comment_id, pullrequest_id=None, repo_slug=None, **kwargs):
+        """ Update a PullRequest comment in one of your repositories.
+            Each PullRequest comment require only the content data field
+            the system autopopulate the rest.
+        """
+        pullrequest_id = pullrequest_id or self.pullrequest_id
+        repo_slug = repo_slug or self.bitbucket.repo_slug or ''
+        url = self.bitbucket.url('UPDATE_COMMENT',
+                                 username=self.bitbucket.username,
+                                 repo_slug=repo_slug,
+                                 pullrequest_id=pullrequest_id,
+                                 comment_id=comment_id)
+        return self.bitbucket.dispatch('PUT', url, auth=self.bitbucket.auth, **kwargs)
+
+    def delete(self, comment_id, pullrequest_id=None, repo_slug=None):
+        """ Delete a PullRequest from one of your repositories.
+        """
+        pullrequest_id = pullrequest_id or self.pullrequest_id
+        repo_slug = repo_slug or self.bitbucket.repo_slug or ''
+        url = self.bitbucket.url('DELETE_COMMENT',
+                                 username=self.bitbucket.username,
+                                 repo_slug=repo_slug,
+                                 pullrequest_id=pullrequest_id,
+                                 comment_id=comment_id)
+        return self.bitbucket.dispatch('DELETE', url, auth=self.bitbucket.auth)

--- a/bitbucket/pullrequest_diff.py
+++ b/bitbucket/pullrequest_diff.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+URLS = {
+    # Get Diff
+    'GET_DIFF': 'repositories/%(username)s/%(repo_slug)s/pullrequests/%(pullrequest_id)s/diff/',
+}
+
+
+class PullRequestDiff(object):
+    """
+    This class provide PullRequest's changesets related methods
+    to Bitbucket objects.
+    """
+
+    def __init__(self, pullrequest):
+        self.pullrequest = pullrequest
+        self.bitbucket = self.pullrequest.bitbucket
+        self.bitbucket.URLS.update(URLS)
+        self.pullrequest_id = pullrequest.pullrequest_id
+
+    def get(self, pullrequest_id=None, repo_slug=None):
+        """
+        Get a PullRequest from one of your repositories.
+        """
+        pullrequest_id = pullrequest_id or self.pullrequest_id
+        repo_slug = repo_slug or self.bitbucket.repo_slug or ''
+        url = self.bitbucket.url_v2('GET_DIFF',
+                                    username=self.bitbucket.username,
+                                    repo_slug=repo_slug,
+                                    pullrequest_id=pullrequest_id)
+
+        success, diff = self.bitbucket.dispatch('GET', url,
+                                                auth=self.bitbucket.auth)
+        if success:
+            # request succeed, return diff
+            return diff
+        else:
+            # request failed
+            return None

--- a/bitbucket/repository.py
+++ b/bitbucket/repository.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
+import json
 from tempfile import NamedTemporaryFile
 from zipfile import ZipFile
+
+from pprint import pprint
 
 
 URLS = {
@@ -139,12 +142,15 @@ class Repository(object):
         if self.bitbucket.repo_tree:
             with NamedTemporaryFile(delete=False) as archive:
                 with ZipFile(archive, 'w') as zip_archive:
-                    for name, file in self.bitbucket.repo_tree.items():
+                    for name, f in self.bitbucket.repo_tree.items():
                         with NamedTemporaryFile(delete=False) as temp_file:
+                            if isinstance(f, dict):
+                                f = json.dumps(f)
+
                             try:
-                                temp_file.write(file.encode('utf-8'))
+                                temp_file.write(f.encode('utf-8'))
                             except UnicodeDecodeError:
-                                temp_file.write(file)
+                                temp_file.write(f)
                         zip_archive.write(temp_file.name, prefix + name)
             return (True, archive.name)
         return (False, 'Could not archive your project.')

--- a/bitbucket/repository.py
+++ b/bitbucket/repository.py
@@ -99,14 +99,16 @@ class Repository(object):
         url = self.bitbucket.url('GET_REPO', username=owner, repo_slug=repo_slug)
         return self.bitbucket.dispatch('GET', url, auth=self.bitbucket.auth)
 
-    def create(self, repo_name, repo_slug=None, owner=None, scm='git', private=True, force_api_version=None, **kwargs):
+    def create(self, repo_name=None, repo_slug=None, owner=None, scm='git', private=True, **kwargs):
         """ Creates a new repository on a Bitbucket account and return it."""
         repo_slug = repo_slug or self.bitbucket.repo_slug or ''
-        if owner and (force_api_version is None or force_api_version == 2):
+
+        if owner:
             url = self.bitbucket.url_v2('CREATE_REPO_V2', username=owner, repo_slug=repo_slug)
         else:
             owner = self.bitbucket.username
             url = self.bitbucket.url('CREATE_REPO')
+
         return self.bitbucket.dispatch('POST', url, auth=self.bitbucket.auth, name=repo_name, scm=scm, is_private=private, **kwargs)
 
     def update(self, repo_slug=None, owner=None, **kwargs):

--- a/bitbucket/repository.py
+++ b/bitbucket/repository.py
@@ -99,10 +99,10 @@ class Repository(object):
         url = self.bitbucket.url('GET_REPO', username=owner, repo_slug=repo_slug)
         return self.bitbucket.dispatch('GET', url, auth=self.bitbucket.auth)
 
-    def create(self, repo_name, repo_slug=None, owner=None, scm='git', private=True, **kwargs):
+    def create(self, repo_name, repo_slug=None, owner=None, scm='git', private=True, force_api_version=None, **kwargs):
         """ Creates a new repository on a Bitbucket account and return it."""
         repo_slug = repo_slug or self.bitbucket.repo_slug or ''
-        if owner:
+        if owner and (force_api_version is None or force_api_version == 2):
             url = self.bitbucket.url_v2('CREATE_REPO_V2', username=owner, repo_slug=repo_slug)
         else:
             owner = self.bitbucket.username

--- a/bitbucket/repository.py
+++ b/bitbucket/repository.py
@@ -5,6 +5,7 @@ from zipfile import ZipFile
 
 URLS = {
     'CREATE_REPO': 'repositories/',
+    'CREATE_REPO_V2': 'repositories/%(username)s/%(repo_slug)s/',
     'GET_REPO': 'repositories/%(username)s/%(repo_slug)s/',
     'UPDATE_REPO': 'repositories/%(username)s/%(repo_slug)s/',
     'DELETE_REPO': 'repositories/%(username)s/%(repo_slug)s/',
@@ -98,9 +99,14 @@ class Repository(object):
         url = self.bitbucket.url('GET_REPO', username=owner, repo_slug=repo_slug)
         return self.bitbucket.dispatch('GET', url, auth=self.bitbucket.auth)
 
-    def create(self, repo_name, scm='git', private=True, **kwargs):
+    def create(self, repo_name, repo_slug=None, owner=None, scm='git', private=True, **kwargs):
         """ Creates a new repository on a Bitbucket account and return it."""
-        url = self.bitbucket.url('CREATE_REPO')
+        repo_slug = repo_slug or self.bitbucket.repo_slug or ''
+        if owner:
+            url = self.bitbucket.url_v2('CREATE_REPO_V2', username=owner, repo_slug=repo_slug)
+        else:
+            owner = self.bitbucket.username
+            url = self.bitbucket.url('CREATE_REPO')
         return self.bitbucket.dispatch('POST', url, auth=self.bitbucket.auth, name=repo_name, scm=scm, is_private=private, **kwargs)
 
     def update(self, repo_slug=None, owner=None, **kwargs):

--- a/bitbucket/repository.py
+++ b/bitbucket/repository.py
@@ -122,7 +122,7 @@ class Repository(object):
         """
         repo_slug = repo_slug or self.bitbucket.repo_slug or ''
         owner = owner or self.bitbucket.username
-        url = self.bitbucket.url('DELETE_REPO', username=owner, repo_slug=repo_slug)
+        url = self.bitbucket.url_v2('DELETE_REPO', username=owner, repo_slug=repo_slug)
         return self.bitbucket.dispatch('DELETE', url, auth=self.bitbucket.auth)
 
     def archive(self, repo_slug=None, owner=None, format='zip', prefix=''):

--- a/bitbucket/repository.py
+++ b/bitbucket/repository.py
@@ -20,12 +20,13 @@ class Repository(object):
         self.bitbucket = bitbucket
         self.bitbucket.URLS.update(URLS)
 
-    def _get_files_in_dir(self, repo_slug=None, dir='/'):
+    def _get_files_in_dir(self, repo_slug=None, owner=None, dir='/'):
         repo_slug = repo_slug or self.bitbucket.repo_slug or ''
+        owner = owner or self.bitbucket.username
         dir = dir.lstrip('/')
         url = self.bitbucket.url(
             'GET_ARCHIVE',
-            username=self.bitbucket.username,
+            username=owner,
             repo_slug=repo_slug,
             format='src')
         dir_url = url + dir
@@ -34,7 +35,7 @@ class Repository(object):
             repo_tree = response[1]
             url = self.bitbucket.url(
                 'GET_ARCHIVE',
-                username=self.bitbucket.username,
+                username=owner,
                 repo_slug=repo_slug,
                 format='raw')
             # Download all files in dir
@@ -45,7 +46,7 @@ class Repository(object):
             # recursively download in dirs
             for directory in repo_tree['directories']:
                 dir_path = '/'.join((dir, directory))
-                self._get_files_in_dir(repo_slug=repo_slug, dir=dir_path)
+                self._get_files_in_dir(repo_slug=repo_slug, owner=owner, dir=dir_path)
 
     def public(self, username=None):
         """ Returns all public repositories from an user.
@@ -60,9 +61,10 @@ class Repository(object):
             pass
         return response
 
-    def all(self):
-        """ Return own repositories."""
-        url = self.bitbucket.url('GET_USER', username=self.bitbucket.username)
+    def all(self, owner=None):
+        """ Return all repositories for a given owner """
+        owner = owner or self.bitbucket.username
+        url = self.bitbucket.url('GET_USER', username=owner)
         response = self.bitbucket.dispatch('GET', url, auth=self.bitbucket.auth)
         try:
             return (response[0], response[1]['repositories'])
@@ -70,39 +72,43 @@ class Repository(object):
             pass
         return response
 
-    def get(self, repo_slug=None):
+    def get(self, repo_slug=None, owner=None):
         """ Get a single repository on Bitbucket and return it."""
         repo_slug = repo_slug or self.bitbucket.repo_slug or ''
-        url = self.bitbucket.url('GET_REPO', username=self.bitbucket.username, repo_slug=repo_slug)
+        owner = owner or self.bitbucket.username
+        url = self.bitbucket.url('GET_REPO', username=owner, repo_slug=repo_slug)
         return self.bitbucket.dispatch('GET', url, auth=self.bitbucket.auth)
 
     def create(self, repo_name, scm='git', private=True, **kwargs):
-        """ Creates a new repository on own Bitbucket account and return it."""
+        """ Creates a new repository on a Bitbucket account and return it."""
         url = self.bitbucket.url('CREATE_REPO')
         return self.bitbucket.dispatch('POST', url, auth=self.bitbucket.auth, name=repo_name, scm=scm, is_private=private, **kwargs)
 
-    def update(self, repo_slug=None, **kwargs):
-        """ Updates repository on own Bitbucket account and return it."""
+    def update(self, repo_slug=None, owner=None, **kwargs):
+        """ Updates repository on a Bitbucket account and return it."""
         repo_slug = repo_slug or self.bitbucket.repo_slug or ''
-        url = self.bitbucket.url('UPDATE_REPO', username=self.bitbucket.username, repo_slug=repo_slug)
+        owner = owner or self.bitbucket.username
+        url = self.bitbucket.url('UPDATE_REPO', username=owner, repo_slug=repo_slug)
         return self.bitbucket.dispatch('PUT', url, auth=self.bitbucket.auth, **kwargs)
 
-    def delete(self, repo_slug=None):
+    def delete(self, repo_slug=None, owner=None):
         """ Delete a repository on own Bitbucket account.
             Please use with caution as there is NO confimation and NO undo.
         """
         repo_slug = repo_slug or self.bitbucket.repo_slug or ''
-        url = self.bitbucket.url('DELETE_REPO', username=self.bitbucket.username, repo_slug=repo_slug)
+        owner = owner or self.bitbucket.username
+        url = self.bitbucket.url('DELETE_REPO', username=owner, repo_slug=repo_slug)
         return self.bitbucket.dispatch('DELETE', url, auth=self.bitbucket.auth)
 
-    def archive(self, repo_slug=None, format='zip', prefix=''):
+    def archive(self, repo_slug=None, owner=None, format='zip', prefix=''):
         """ Get one of your repositories and compress it as an archive.
             Return the path of the archive.
 
             format parameter is curently not supported.
         """
+        owner = owner or self.bitbucket.username
         prefix = '%s'.lstrip('/') % prefix
-        self._get_files_in_dir(repo_slug=repo_slug, dir='/')
+        self._get_files_in_dir(repo_slug=repo_slug, owner=owner, dir='/')
         if self.bitbucket.repo_tree:
             with NamedTemporaryFile(delete=False) as archive:
                 with ZipFile(archive, 'w') as zip_archive:

--- a/bitbucket/repository.py
+++ b/bitbucket/repository.py
@@ -114,7 +114,10 @@ class Repository(object):
                 with ZipFile(archive, 'w') as zip_archive:
                     for name, file in self.bitbucket.repo_tree.items():
                         with NamedTemporaryFile(delete=False) as temp_file:
-                            temp_file.write(file.encode('utf-8'))
+                            try:
+                                temp_file.write(file.encode('utf-8'))
+                            except UnicodeDecodeError:
+                                temp_file.write(file)
                         zip_archive.write(temp_file.name, prefix + name)
             return (True, archive.name)
         return (False, 'Could not archive your project.')

--- a/bitbucket/tests/private/issue_comment.py
+++ b/bitbucket/tests/private/issue_comment.py
@@ -13,6 +13,7 @@ class IssueCommentAuthenticatedMethodsTest(AuthenticatedBitbucketTest):
             title=u'Test Issue Bitbucket API',
             content=u'Test Issue Bitbucket API',
             responsible=self.bb.username,
+            owner=self.bb.username,
             status=u'new',
             kind=u'bug',)
         # Save latest issue's id
@@ -34,6 +35,7 @@ class IssueCommentAuthenticatedMethodsTest(AuthenticatedBitbucketTest):
         content = u'Test Issue comment Bitbucket API'
         # Test create an issue comment
         success, result = self.bb.issue.comment.create(
+            owner=self.bb.username,
             content=content)
         self.assertTrue(success)
         self.assertIsInstance(result, dict)
@@ -43,7 +45,9 @@ class IssueCommentAuthenticatedMethodsTest(AuthenticatedBitbucketTest):
 
     def _get_issue_comment(self):
         # Test get an issue comment.
-        success, result = self.bb.issue.comment.get(comment_id=self.comment_id)
+        success, result = self.bb.issue.comment.get(
+            owner=self.bb.username,
+            comment_id=self.comment_id)
         self.assertTrue(success)
         self.assertIsInstance(result, dict)
         # Test get an invalid issue comment.
@@ -54,6 +58,7 @@ class IssueCommentAuthenticatedMethodsTest(AuthenticatedBitbucketTest):
         # Test issue comment update.
         test_content = 'Test content'
         success, result = self.bb.issue.comment.update(
+            owner=self.bb.username,
             comment_id=self.comment_id,
             content=test_content)
         self.assertTrue(success)
@@ -63,6 +68,7 @@ class IssueCommentAuthenticatedMethodsTest(AuthenticatedBitbucketTest):
     def _delete_issue_comment(self):
         # Test issue comment delete.
         success, result = self.bb.issue.comment.delete(
+            owner=self.bb.username,
             comment_id=self.comment_id)
         self.assertTrue(success)
         self.assertEqual(result, '')


### PR DESCRIPTION
Addresses issue #14.

Sometimes you need to pull data from repos that aren't owned by you, but rather by a team that you belong to. This pull request allows an owner/username to be passed to several APIs and the API will do its thing as long as the authenticated user has access to the requested repository.

I didn't add anything to the tests, but I did run them and everything still seems okay.
