### PR TITLE
Dispatch better error handling

### DIFF
--- a/bitbucket/bitbucket.py
+++ b/bitbucket/bitbucket.py
@@ -243,12 +243,20 @@ class Bitbucket(object):
                 False,
                 'Unauthorized access, '
                 'please check your credentials.')
-        elif status >= 400 and status < 500:
-            return (False, 'Service not found.')
+        elif status == 404:
+            return (False, dict(message='Service not found', reason=error, code=status))
+        elif status == 400:
+            return (False, dict(message='Bad request sent to server.', reason=error, code=status))
+        elif status == 401:
+            return (False, dict(message='Not enough privileges.', reason=error, code=status))
+        elif status == 403:
+            return (False, dict(message='Not authorized.', reason=error, code=status))
+        elif status == 402 or status >= 405:
+            return (False, dict(message='Request error.', reason=error, code=status))
         elif status >= 500 and status < 600:
-                return (False, 'Server error.')
+                return (False, dict(message='Server error.', reason=error, code=status))
         else:
-            return (False, error)
+            return (False, dict(message='Unidentified error.', reason=error, code=status))
 
     def url(self, action, **kwargs):
         """ Construct and return the URL for a specific API service. """

--- a/bitbucket/bitbucket.py
+++ b/bitbucket/bitbucket.py
@@ -278,6 +278,8 @@ class Bitbucket(object):
             return (response[0], response[1]['user'])
         except TypeError:
             pass
+        except KeyError:
+            pass
         return response
 
     def get_tags(self, repo_slug=None):

--- a/bitbucket/repository.py
+++ b/bitbucket/repository.py
@@ -58,6 +58,8 @@ class Repository(object):
             return (response[0], response[1]['repositories'])
         except TypeError:
             pass
+        except KeyError:
+            pass
         return response
 
     def all(self):

--- a/bitbucket/tests/public.py
+++ b/bitbucket/tests/public.py
@@ -114,7 +114,9 @@ class BitbucketAnnonymousMethodsTest(AnonymousBitbucketTest):
         self.bb.username = None
         success, result = self.bb.get_user()
         self.assertFalse(success)
-        self.assertEqual(result, 'Service not found.')
+        self.assertEqual(result['message'], 'Service not found')
+        self.assertEqual(result['reason'], 'NOT FOUND')
+        self.assertEqual(result['code'], 404)
 
     def test_get_public_repos(self):
         """ Test public_repos on specific user."""
@@ -134,7 +136,9 @@ class BitbucketAnnonymousMethodsTest(AnonymousBitbucketTest):
         self.bb.username = None
         success, result = self.bb.repository.public()
         self.assertFalse(success)
-        self.assertEqual(result, 'Service not found.')
+        self.assertEqual(result['message'], 'Service not found')
+        self.assertEqual(result['reason'], 'NOT FOUND')
+        self.assertEqual(result['code'], 404)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Instead of a generic 'service not found' error for any request with HTTP
error code between 400 and 500, added checks for 400, 401, 403 and for
all the others in that range, give a generic 'Request error' message.

Also, changed the second part of the error checking from a simple string
into a dict with more details on the error (with message as string, reason
as the given json object, and code as the HTTP code returned, to make it
easier to act accordingly to the type of error returned by the API.

I updated the tests with this change implemented as well.
