### PR TITLE
Added user parameter to the repository get method

### DIFF
--- a/bitbucket/repository.py
+++ b/bitbucket/repository.py
@@ -70,11 +70,12 @@ class Repository(object):
             pass
         return response
 
-    def get(self, repo_slug=None):
+    def get(self, user=None, repo_slug=None):
         """ Get a single repository on Bitbucket and return it."""
+        username = user or self.bitbucket.username
         repo_slug = repo_slug or self.bitbucket.repo_slug or ''
-        url = self.bitbucket.url('GET_REPO', username=self.bitbucket.username, repo_slug=repo_slug)
-        return self.bitbucket.dispatch('GET', url, auth=self.bitbucket.auth)
+        url = self.url('GET_REPO', username=username, repo_slug=repo_slug)
+        return self.dispatch('GET', url, auth=self.bitbucket.auth)
 
     def create(self, repo_name, scm='git', private=True, **kwargs):
         """ Creates a new repository on own Bitbucket account and return it."""


### PR DESCRIPTION
makes it possible to retrieve a repository from another namespace or from the user's namespace, when the user logged in with email, given that the user parameter is set with `bb.get_user()[1]['username']`.

This should address #6, given that the caller does:

```
bb.repository.get(user=bb.get_user()[1]['username'], repo_slug=repo_slug)
```

HTH
